### PR TITLE
Various small improvements

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -778,8 +778,7 @@ if craftable_setting or not (unified_inventory_modpath or sfinv_modpath or sfinv
 				if not mcl_formspec_modpath then return nil end
 				local name = user:get_player_name()
 				minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
-			end
-		end),
+			end),
 		on_place = ternary(not mcl_formspec_modpath, nil,
 			function(itemstack, user, pointed_thing)
 				if not user:get_player_control().sneak then 
@@ -790,8 +789,7 @@ if craftable_setting or not (unified_inventory_modpath or sfinv_modpath or sfinv
 				end
 				local name = user:get_player_name()
 				minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
-			end
-		end),
+			end),
 	})
 
 	minetest.register_craft({

--- a/init.lua
+++ b/init.lua
@@ -806,6 +806,7 @@ end
 
 local chat_command = minetest.settings:get_bool("personal_log_chat_command", false)
 local chat_command_priv = minetest.settings:get_bool("personal_log_chat_command_privilege", false)
+	or minetest.settings:get_bool("personal_log_chat_command_priviledge", false) -- backwards compat
 
 if chat_command then
 

--- a/init.lua
+++ b/init.lua
@@ -545,6 +545,8 @@ local function make_personal_log_formspec(player)
 	if minetest.check_player_privs(player_name, "teleport") then
 		can_teleport = true
 	elseif personal_log_teleport_privilege and minetest.check_player_privs(player_name, "personal_log_teleport")
+		can_teleport = true
+	end
 	if category_index == LOCATION_CATEGORY and can_teleport then
 		formspec[#formspec+1] = "button[7,0.75;2,0.5;teleport;"..S("Teleport") .."]"
 	end

--- a/init.lua
+++ b/init.lua
@@ -764,6 +764,23 @@ minetest.register_craftitem("personal_log:book", {
 	inventory_image = "personal_log_open_book.png",
 	groups = {book = 1, flammable = 3},
 	on_use = function(itemstack, user, pointed_thing)
+		if mcl_formspec_modpath then return nil end
+		local name = user:get_player_name()
+		minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+	end,
+	on_secondary_use = function(itemstack, user, pointed_thing)
+		if not mcl_formspec_modpath then return nil end
+		local name = user:get_player_name()
+		minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+	end,
+	on_secondary_use = function(itemstack, user, pointed_thing)
+		if not mcl_formspec_modpath then return nil end
+        if not user:get_player_control().sneak then 
+            local new_stack = mcl_util.call_on_rightclick(itemstack, user, pointed_thing)
+            if new_stack then
+                return new_stack
+            end
+        end
 		local name = user:get_player_name()
 		minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
 	end,
@@ -771,6 +788,7 @@ minetest.register_craftitem("personal_log:book", {
 
 minetest.register_craft({
 	output = "personal_log:book",
+	type = "shapeless",
 	recipe = {{book_unwritten, book_unwritten}}
 })
 

--- a/init.lua
+++ b/init.lua
@@ -768,21 +768,24 @@ minetest.register_craftitem("personal_log:book", {
 		local name = user:get_player_name()
 		minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
 	end,
-	on_secondary_use = function(itemstack, user, pointed_thing)
-		if not mcl_formspec_modpath then return nil end
-		local name = user:get_player_name()
-		minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+	on_secondary_use = if not mcl_formspec_modpath then nil else
+		function(itemstack, user, pointed_thing)
+			if not mcl_formspec_modpath then return nil end
+			local name = user:get_player_name()
+			minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+		end
 	end,
-	on_secondary_use = function(itemstack, user, pointed_thing)
-		if not mcl_formspec_modpath then return nil end
-        if not user:get_player_control().sneak then 
-            local new_stack = mcl_util.call_on_rightclick(itemstack, user, pointed_thing)
-            if new_stack then
-                return new_stack
-            end
-        end
-		local name = user:get_player_name()
-		minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+	on_place = if not mcl_formspec_modpath then nil else
+		function(itemstack, user, pointed_thing)
+			if not user:get_player_control().sneak then 
+				local new_stack = mcl_util.call_on_rightclick(itemstack, user, pointed_thing)
+				if new_stack then
+					return new_stack
+				end
+			end
+			local name = user:get_player_name()
+			minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+		end
 	end,
 })
 

--- a/init.lua
+++ b/init.lua
@@ -759,41 +759,46 @@ local craftable_setting = minetest.settings:get_bool("personal_log_craftable_ite
 
 if craftable_setting or not (unified_inventory_modpath or sfinv_modpath or sfinv_buttons_modpath) then
 
-minetest.register_craftitem("personal_log:book", {
-	description = S("Personal Log"),
-	inventory_image = "personal_log_open_book.png",
-	groups = {book = 1, flammable = 3},
-	on_use = function(itemstack, user, pointed_thing)
-		if mcl_formspec_modpath then return nil end
-		local name = user:get_player_name()
-		minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
-	end,
-	on_secondary_use = if not mcl_formspec_modpath then nil else
-		function(itemstack, user, pointed_thing)
-			if not mcl_formspec_modpath then return nil end
-			local name = user:get_player_name()
-			minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
-		end
-	end,
-	on_place = if not mcl_formspec_modpath then nil else
-		function(itemstack, user, pointed_thing)
-			if not user:get_player_control().sneak then 
-				local new_stack = mcl_util.call_on_rightclick(itemstack, user, pointed_thing)
-				if new_stack then
-					return new_stack
-				end
-			end
-			local name = user:get_player_name()
-			minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
-		end
-	end,
-})
+--I don't like needing to do this...
+	local function ternary(condition, truevalue, falsevalue)
+		if condition then return true else return false end
+	end
 
-minetest.register_craft({
-	output = "personal_log:book",
-	type = "shapeless",
-	recipe = {book_unwritten, book_unwritten}
-})
+	minetest.register_craftitem("personal_log:book", {
+		description = S("Personal Log"),
+		inventory_image = "personal_log_open_book.png",
+		groups = {book = 1, flammable = 3},
+		on_use = function(itemstack, user, pointed_thing)
+			if mcl_formspec_modpath then return nil end
+			local name = user:get_player_name()
+			minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+		end,
+		on_secondary_use = ternary(not mcl_formspec_modpath, nil,
+			function(itemstack, user, pointed_thing)
+				if not mcl_formspec_modpath then return nil end
+				local name = user:get_player_name()
+				minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+			end
+		end),
+		on_place = ternary(not mcl_formspec_modpath, nil,
+			function(itemstack, user, pointed_thing)
+				if not user:get_player_control().sneak then 
+					local new_stack = mcl_util.call_on_rightclick(itemstack, user, pointed_thing)
+					if new_stack then
+						return new_stack
+					end
+				end
+				local name = user:get_player_name()
+				minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+			end
+		end),
+	})
+
+	minetest.register_craft({
+		output = "personal_log:book",
+		type = "shapeless",
+		recipe = {book_unwritten, book_unwritten}
+	})
 
 end
 

--- a/init.lua
+++ b/init.lua
@@ -767,7 +767,6 @@ if craftable_setting or not (unified_inventory_modpath or sfinv_modpath or sfinv
 
 	if mcl_formspec_modpath then
 		attributes.on_secondary_use = function(itemstack, user, pointed_thing)
-			if mcl_formspec_modpath then return nil end
 			local name = user:get_player_name()
 			minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
 		end

--- a/init.lua
+++ b/init.lua
@@ -650,7 +650,8 @@ local function on_player_receive_fields(player, fields, update_callback)
 	if fields.teleport
 		and category == LOCATION_CATEGORY
 		and valid_entry_selected
-		and minetest.check_player_privs(player_name, "teleport") then
+		and (minetest.check_player_privs(player_name, "teleport")
+		or (personal_log_teleport_privilege and minetest.check_player_privs(player_name, "personal_log_teleport"))) then
 		local pos_string = modstore:get_string(player_name .. "_category_" .. category .. "_entry_" .. entry_selected .. "_topic")
 		local pos = minetest.string_to_pos(pos_string)
 		if pos then

--- a/init.lua
+++ b/init.lua
@@ -763,7 +763,7 @@ end
 -- Chat command
 
 local chat_command = minetest.settings:get_bool("personal_log_chat_command", false)
-local chat_command_priv = minetest.settings:get_bool("personal_log_chat_command_priviledge", false)
+local chat_command_priv = minetest.settings:get_bool("personal_log_chat_command_privilege", false)
 
 if chat_command then
 

--- a/init.lua
+++ b/init.lua
@@ -786,7 +786,6 @@ if craftable_setting or not (unified_inventory_modpath or sfinv_modpath or sfinv
 		end
 	else
 		attributes.on_use = function(itemstack, user, pointed_thing)
-			if mcl_formspec_modpath then return nil end
 			local name = user:get_player_name()
 			minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
 		end

--- a/init.lua
+++ b/init.lua
@@ -759,38 +759,37 @@ local craftable_setting = minetest.settings:get_bool("personal_log_craftable_ite
 
 if craftable_setting or not (unified_inventory_modpath or sfinv_modpath or sfinv_buttons_modpath) then
 
---I don't like needing to do this...
-	local function ternary(condition, truevalue, falsevalue)
-		if condition then return true else return false end
-	end
-
-	minetest.register_craftitem("personal_log:book", {
+	attributes = {
 		description = S("Personal Log"),
 		inventory_image = "personal_log_open_book.png",
 		groups = {book = 1, flammable = 3},
-		on_use = function(itemstack, user, pointed_thing)
+	}
+
+	if mcl_formspec_modpath then
+		attributes.on_secondary_use = function(itemstack, user, pointed_thing)
 			if mcl_formspec_modpath then return nil end
 			local name = user:get_player_name()
 			minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
-		end,
-		on_secondary_use = ternary(not mcl_formspec_modpath, nil,
-			function(itemstack, user, pointed_thing)
-				if not mcl_formspec_modpath then return nil end
-				local name = user:get_player_name()
-				minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
-			end),
-		on_place = ternary(not mcl_formspec_modpath, nil,
-			function(itemstack, user, pointed_thing)
-				if not user:get_player_control().sneak then 
-					local new_stack = mcl_util.call_on_rightclick(itemstack, user, pointed_thing)
-					if new_stack then
-						return new_stack
-					end
+		end
+		attributes.on_place = function(itemstack, user, pointed_thing)
+			if not user:get_player_control().sneak then 
+				local new_stack = mcl_util.call_on_rightclick(itemstack, user, pointed_thing)
+				if new_stack then
+					return new_stack
 				end
-				local name = user:get_player_name()
-				minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
-			end),
-	})
+			end
+			local name = user:get_player_name()
+			minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+		end
+	else
+		attributes.on_use = function(itemstack, user, pointed_thing)
+			if mcl_formspec_modpath then return nil end
+			local name = user:get_player_name()
+			minetest.show_formspec(name,"personal_log:root", make_personal_log_formspec(user))
+		end
+	end
+
+	minetest.register_craftitem("personal_log:book", attributes)
 
 	minetest.register_craft({
 		output = "personal_log:book",

--- a/init.lua
+++ b/init.lua
@@ -544,7 +544,7 @@ local function make_personal_log_formspec(player)
 	local can_teleport = false
 	if minetest.check_player_privs(player_name, "teleport") then
 		can_teleport = true
-	elseif personal_log_teleport_privilege and minetest.check_player_privs(player_name, "personal_log_teleport")
+	elseif personal_log_teleport_privilege and minetest.check_player_privs(player_name, "personal_log_teleport") then
 		can_teleport = true
 	end
 	if category_index == LOCATION_CATEGORY and can_teleport then

--- a/init.lua
+++ b/init.lua
@@ -789,7 +789,7 @@ minetest.register_craftitem("personal_log:book", {
 minetest.register_craft({
 	output = "personal_log:book",
 	type = "shapeless",
-	recipe = {{book_unwritten, book_unwritten}}
+	recipe = {book_unwritten, book_unwritten}
 })
 
 end

--- a/init.lua
+++ b/init.lua
@@ -18,6 +18,8 @@ local ccompass_recalibration_allowed = minetest.settings:get_bool("ccompass_reca
 local ccompass_restrict_target = minetest.settings:get_bool("ccompass_restrict_target", false)
 local ccompass_description_prefix = "^Compass to "
 
+local personal_log_teleport_privilege = minetest.settings:get_bool("personal_log_teleport_privilege", false)
+
 local S = minetest.get_translator(modname)
 
 local categories = {
@@ -50,6 +52,15 @@ end
 local mcl_formspec_itemslot
 if mcl_formspec_modpath then
 	mcl_formspec_itemslot = mcl_formspec.get_itemslot_bg
+end
+
+if personal_log_teleport_privilege then
+	minetest.register_privilege("personal_log_teleport", {
+        description =S("Allows the player to teleport using the personal log"),
+        give_to_singleplayer = false,
+        give_to_admin = true,
+	})
+	privs = {personal_log_teleport=true}
 end
 
 --------------------------------------------------------
@@ -530,8 +541,11 @@ local function make_personal_log_formspec(player)
 		.."button[4.5,0;2,0.5;move_up;"..S("Move Up").."]"
 		.."button[4.5,0.75;2,0.5;move_down;"..S("Move Down").."]"
 		.."button[7,0;2,0.5;delete;"..S("Delete") .."]"
-
-	if category_index == LOCATION_CATEGORY and minetest.check_player_privs(player_name, "teleport") then
+	local can_teleport = false
+	if minetest.check_player_privs(player_name, "teleport") then
+		can_teleport = true
+	elseif personal_log_teleport_privilege and minetest.check_player_privs(player_name, "personal_log_teleport")
+	if category_index == LOCATION_CATEGORY and can_teleport then
 		formspec[#formspec+1] = "button[7,0.75;2,0.5;teleport;"..S("Teleport") .."]"
 	end
 
@@ -818,3 +832,4 @@ end
 personal_log.add_general_entry = function(player_name, content, general_topic)
 	add_entry_for_player(player_name, GENERAL_CATEGORY, content, general_topic)
 end
+

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,4 +1,4 @@
 personal_log_inventory_button (Access via a button in SFInv/Unified Inventory) bool true
 personal_log_craftable_item (Access via a craftable item) bool false
 personal_log_chat_command (Allow the /log chat command to open the log) bool false
-personal_log_chat_command_priviledge (The personal_log privilege is required to access the log via chat command) bool false
+personal_log_chat_command_privilege (The personal_log privilege is required to access the log via chat command) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -2,3 +2,6 @@ personal_log_inventory_button (Access via a button in SFInv/Unified Inventory) b
 personal_log_craftable_item (Access via a craftable item) bool false
 personal_log_chat_command (Allow the /log chat command to open the log) bool false
 personal_log_chat_command_privilege (The personal_log privilege is required to access the log via chat command) bool false
+
+# True if the "personal_log_teleport" privilege is required to teleport, if false, the "teleport" privilege is used instead.
+personal_log_teleport_privilege (Add personal_log_teleport privilege) bool false


### PR DESCRIPTION
* Crafting recipe for item is now shapeless
* Item now uses right click to open in MineClone (otherwise still left click)
* Added `personal_log_teleport` privilege (and `personal_log_teleport_privilege` setting to enable), in case you only want people to teleport to places they've already been to and saved in the log, and not use `/teleport`
* Replaced `priviledge` with `privilege` everywhere it's misspelled
* Tested in both MineClone and Minetest Game